### PR TITLE
Fixed crashing issues with certain file paths and names

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/SchemaScanLib/deps/hashlib2plus/src/hl_hashwrapper.h" charset="windows-1252" />
+  </component>
+</project>

--- a/SchemaScanConsole/SchemaScanConsole.cpp
+++ b/SchemaScanConsole/SchemaScanConsole.cpp
@@ -5,9 +5,9 @@
 
 int main(int argc, char* argv[]) {
     try {
-        std::wstring path;
-        std::cout << "Starting...\n";
-        path = SchemaUtils::stringToWString(R"(E:\Electronics Repair\Schematic Program Test\rustest)");
+        std::u32string path;
+        std::cout << "Starting...\n\n";
+        path = U"E:\\Electronics Repair\\Schematics & Boardviews";
         //  std::cout << "Please enter the full path to the schematic: \n";
         // std::cin >> path;
 //        Schematic schematic(path);
@@ -23,11 +23,11 @@ int main(int argc, char* argv[]) {
         SchematicHandler handler(path);
         std::cout << "Found " << handler.getFoundFilesCount() << " schematic(s)\n";
         for (const auto &schematic : handler.getSchematics()) {
-            std::cout << "Valid Schematic: " << SchemaUtils::wStringToString(schematic->getFileName()) << "\n";
+            std::cout << "Valid Schematic: " << SchemaUtils::u32StringToStdString(schematic->getFileName()) << "\n";
         }
         std::cout << "\n\n";
         for (const auto &schematic : handler.getSkippedSchematics()) {
-            std::cout << "Skipped Schematic: " << SchemaUtils::wStringToString(schematic) << "\n";
+            std::cout << "Skipped Schematic: " << SchemaUtils::u32StringToStdString(schematic) << "\n";
         }
         std::cout << "Scanned " << handler.getSchematicCount() << " schematic(s)\n";
         std::cout << "Skipped " << handler.getSkippedSchematicCount() << " schematic(s)\n";

--- a/SchemaScanLib/Schematic.h
+++ b/SchemaScanLib/Schematic.h
@@ -11,31 +11,31 @@
 #include <string>
 
 #include <podofo/podofo.h>
+#include <hashlibpp.h>
+
 #include "utils/SchemaUtils.h"
 
 class Schematic {
 public:
-    Schematic(const std::wstring &fpath);
+    Schematic(const std::u32string &fpath);
     ~Schematic(){};
     // Functions
     std::map<std::string, std::vector<int>> Search(const std::string &searchTerm, bool includePath) const;
-    [[nodiscard]] std::wstring getFileName() const;
-    [[nodiscard]] std::wstring getFilePath() const;
+    [[nodiscard]] std::u32string getFileName() const;
+    [[nodiscard]] std::u32string getFilePath() const;
     [[nodiscard]] unsigned int getPageCount() const;
     [[nodiscard]] std::string getMD5() const;
-    [[nodiscard]] std::vector<std::wstring> getParsedPages() const;
-    [[nodiscard]] std::wstring getParsedPage(unsigned int page) const;
+    [[nodiscard]] std::vector<std::u32string> getParsedPages() const;
+    [[nodiscard]] std::u32string getParsedPage(unsigned int page) const;
 private:
     // Class Members
-    std::wstring file_name_; // file name and extension, not a full path
-    std::wstring path_; // absolute path of the file, including file name and extension
+    std::u32string file_name_; // file name and extension, not a full path
+    std::u32string path_; // absolute path of the file, including file name and extension
     std::string md5_hash_; // the md5 hash of the file. empty if it cannot be calculated
-    std::vector<std::wstring> parsed_pages_; // contains the parsed text of each page of the file
+    std::vector<std::u32string> parsed_pages_; // contains the parsed text of each page of the file
     // Functions
-    void setup(const std::wstring &fpath);
     void setHash();
     void parsePages();
     void setInfo();
     void setFileName();
-
 };

--- a/SchemaScanLib/SchematicHandler.cpp
+++ b/SchemaScanLib/SchematicHandler.cpp
@@ -4,7 +4,7 @@
 
 #include "SchematicHandler.h"
 
-SchematicHandler::SchematicHandler(const std::wstring &path) {
+SchematicHandler::SchematicHandler(const std::u32string &path) {
     base_directory_ = path;
     if (SchemaUtils::isPdfFile(path)) {
         std::cout << "Given path points directly at a single schematic: " << "\n";
@@ -21,7 +21,7 @@ SchematicHandler::~SchematicHandler() {
 }
 
 // Scans all Schematics gathered from Search()
-// Includes error checking via checking for empty hash
+// Catches all exceptions thrown during Schematic object creation, and skips adding to vector if any throws occur
 void SchematicHandler::Scan() {
     for (const auto &path : fpaths_) {
         try {
@@ -31,28 +31,38 @@ void SchematicHandler::Scan() {
                 schematics_.push_back(temp);
             }
             else {
-                this->skipped_schematics_.push_back(temp->getFilePath());
                 delete temp;
             }
         }
-        catch (const std::out_of_range &e) {
-            std::cerr << "Incorrect file path or type, cannot create Schematic object from file. Skipping "
-                      << SchemaUtils::wStringToString(path) << "\n";
+        catch (const std::out_of_range&) {
+            std::cerr << "Incorrect file path or type, skipping creation of Schematic object: "
+                      << SchemaUtils::u32StringToStdString(path) << "\n";
+            skipped_schematic_paths_.push_back(path);
+        }
+        catch (const hlException&) {
+            std::cerr << "Could not get hash of file, skipping creation of Schematic object: "
+                      << SchemaUtils::u32StringToStdString(path) << "\n";
+            skipped_schematic_paths_.push_back(path);
+        }
+        catch (...) {
+            std::cerr << "Could not parse pdf file (or other error), skipping creation of Schematic object: "
+                      << SchemaUtils::u32StringToStdString(path) << "\n";
+            skipped_schematic_paths_.push_back(path);
         }
     }
 }
 
 // Searches the directory recursively for all schematics (ensures they're .pdf files), and adds the full path to fpaths_
 void SchematicHandler::Search() {
-    std::wstring prefix = L"\\\\?\\";
+    std::u32string prefix = U"\\\\?\\";
     try {
         // Prefix and directory option necessary for long file paths on Windows. Without these the iteration stops
         // and throws an error when it encounters a path that's too long. The directory option also keeps the iterator
         // from throwing an error if it hits a directory or file that it doesn't have permission to access
         for (const auto &pathIt : std::filesystem::recursive_directory_iterator(
                 prefix + base_directory_, std::filesystem::directory_options::skip_permission_denied)) {
-            if (SchemaUtils::isPdfFile(pathIt.path().wstring())) {
-                fpaths_.insert(pathIt.path().wstring());
+            if (SchemaUtils::isPdfFile(pathIt.path().u32string())) {
+                fpaths_.insert(pathIt.path().u32string());
             }
         }
     }
@@ -62,7 +72,7 @@ void SchematicHandler::Search() {
     }
     // TODO: Remove this? Just used for testing, but maybe useful for the final program?
     for (const auto &path_str : fpaths_) {
-        std::cout << "Found Schematic: " << SchemaUtils::wStringToString(path_str) << "\n";
+        std::cout << "Found Schematic: " << SchemaUtils::u32StringToStdString(path_str) << "\n";
     }
 }
 
@@ -79,9 +89,9 @@ std::vector<Schematic *> SchematicHandler::getSchematics() const {
 }
 
 int SchematicHandler::getSkippedSchematicCount() const {
-    return int(this->skipped_schematics_.size());
+    return int(this->skipped_schematic_paths_.size());
 }
 
-std::vector<std::wstring> SchematicHandler::getSkippedSchematics() const {
-    return this->skipped_schematics_;
+std::vector<std::u32string> SchematicHandler::getSkippedSchematics() const {
+    return this->skipped_schematic_paths_;
 }

--- a/SchemaScanLib/SchematicHandler.h
+++ b/SchemaScanLib/SchematicHandler.h
@@ -16,20 +16,21 @@
 
 class SchematicHandler {
 public:
-    SchematicHandler(const std::wstring &path);
+    SchematicHandler(const std::u32string &path);
     ~SchematicHandler();
     [[nodiscard]] int getSchematicCount() const;
     [[nodiscard]] int getFoundFilesCount() const;
     [[nodiscard]] int getSkippedSchematicCount() const;
-    [[nodiscard]] std::vector<std::wstring> getSkippedSchematics() const;
+    [[nodiscard]] std::vector<std::u32string> getSkippedSchematics() const;
     [[nodiscard]] std::vector<Schematic*> getSchematics() const;
+
 private:
     void Scan();
     void Search();
-    std::set<std::wstring> fpaths_; // contains absolute paths of all files found, valid or invalid
+    std::set<std::u32string> fpaths_; // contains absolute paths of all files found, valid or invalid
     std::vector<Schematic*> schematics_; // contains valid parsed Schematic objects
-    std::vector<std::wstring> skipped_schematics_; // contains file paths of skipped schematics (failed to calculate hash which means it would likely fail to scan)
-    std::wstring base_directory_; // initial directory used to search for files
+    std::vector<std::u32string> skipped_schematic_paths_; // contains file paths of skipped schematics (failed to calculate hash which means it would likely fail to scan)
+    std::u32string base_directory_; // initial directory used to search for files
     std::set<std::string> hash_set_; // contains hashes of the valid parsed Schematic objects in schematics_.
                                      // used to weed out duplicates
 };

--- a/SchemaScanLib/utils/SchemaUtils.cpp
+++ b/SchemaScanLib/utils/SchemaUtils.cpp
@@ -10,18 +10,19 @@
  * @param fpath The (absolute) file path that you wish to check
  * @return A boolean, whether the path points directly to a pdf file
  */
-bool SchemaUtils::isPdfFile(const std::wstring &fpath) {
+bool SchemaUtils::isPdfFile(const std::u32string &fpath) {
     return std::filesystem::path(fpath).extension() == ".pdf";
 }
 
-// Converts a std::wstring to std::string
-std::string SchemaUtils::wStringToString(const std::wstring &w_string) {
-    static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t > converter;
-    return converter.to_bytes(w_string);
+// Converts a std::u32string to std::string
+std::string SchemaUtils::u32StringToStdString(const std::u32string &u32_string) {
+    static std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t > converter;
+    return converter.to_bytes(u32_string);
 }
 
-std::wstring SchemaUtils::stringToWString(const std::string &string) {
-    static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t > converter;
+// converts std::string to std::u32string
+std::u32string SchemaUtils::stdStringToU32String(const std::string &string) {
+    static std::wstring_convert<std::codecvt_utf8<char32_t >, char32_t > converter;
     return converter.from_bytes(string);
 }
 

--- a/SchemaScanLib/utils/SchemaUtils.h
+++ b/SchemaScanLib/utils/SchemaUtils.h
@@ -10,9 +10,9 @@
 
 class SchemaUtils {
 public:
-    static bool isPdfFile(const std::wstring &fpath);
-    static std::string wStringToString(const std::wstring &w_string);
-    static std::wstring stringToWString(const std::string &string);
+    static bool isPdfFile(const std::u32string &fpath);
+    static std::string u32StringToStdString(const std::u32string &u32_string);
+    static std::u32string stdStringToU32String(const std::string &string);
 };
 
 


### PR DESCRIPTION
Non-ascii names, hashing issues, and pdf parsing issues no longer crash the program. These files are currently being skipped, more investigation is needed in the future to see what's "wrong" with these files and why they cannot be processed