### PR TITLE
Converted all u32string to wstring, and added windows cache path

### DIFF
--- a/SchemaScanConsole/SchemaScanConsole.cpp
+++ b/SchemaScanConsole/SchemaScanConsole.cpp
@@ -3,11 +3,11 @@
 
 #include <iostream>
 
-int main(int argc, char* argv[]) {
+int wmain(int argc, wchar_t* argv[]) {
     try {
-        std::u32string path;
+        std::wstring path;
         std::cout << "Starting...\n\n";
-        path = U"E:\\Electronics Repair\\Schematic Program Test\\smalltest";
+        path = L"E:\\Electronics Repair\\Schematic Program Test\\smalltest";
         //  std::cout << "Please enter the full path to the schematic: \n";
         // std::cin >> path;
 //        Schematic schematic(path);
@@ -24,19 +24,18 @@ int main(int argc, char* argv[]) {
         // Parsing testing
         std::cout << "Found " << handler.getFoundFilesCount() << " schematic(s)\n";
         for (const auto &schematic : handler.getSchematics()) {
-            std::cout << "Valid Schematic: " << SchemaUtils::u32StringToStdString(schematic->getFileName()) << "\n";
+            std::wcout << "Valid Schematic: " << schematic->getFileName() << "\n";
         }
         std::cout << "\n\n";
         for (const auto &schematic : handler.getSkippedSchematics()) {
-            std::cout << "Skipped Schematic: " << SchemaUtils::u32StringToStdString(schematic) << "\n";
+            std::wcout << "Skipped Schematic: " << schematic << "\n";
         }
         std::cout << "Scanned " << handler.getSchematicCount() << " schematic(s)\n";
         std::cout << "Skipped " << handler.getSkippedSchematicCount() << " schematic(s)\n";
 
         // Cache testing
-        // TODO: Have user specify the cachePath
-        std::u32string cachePath = U"E:\\Electronics Repair\\Schematic Program Test\\cache\\";
-        handler.cacheAll(cachePath, true);
+        // std::wstring winCachePath = U"E:\\Electronics Repair\\Schematic Program Test\\cache\\";
+        handler.cacheAll(true);
     }
     catch (std::out_of_range &e) {
         std::cout << "Invalid: " << e.what() << "\n";

--- a/SchemaScanLib/Schematic.h
+++ b/SchemaScanLib/Schematic.h
@@ -12,25 +12,24 @@
 
 class Schematic {
 public:
-    Schematic(const std::u32string &fpath);
+    Schematic(const std::wstring &fpath);
     Schematic(const nlohmann::ordered_json &jsonObj);
     // Functions
     std::map<std::string, std::vector<int>> Search(const std::string &searchTerm, bool includePath) const;
-    [[nodiscard]] std::u32string getFileName() const;
-    [[nodiscard]] std::u32string getFileNameNoExt() const;
-    [[nodiscard]] std::u32string getFilePath() const;
+    [[nodiscard]] std::wstring getFileName() const;
+    [[nodiscard]] std::wstring getFileNameNoExt() const;
+    [[nodiscard]] std::wstring getFilePath() const;
     [[nodiscard]] unsigned int getPageCount() const;
     [[nodiscard]] std::string getMD5() const;
-    [[nodiscard]] std::vector<std::u32string> getParsedPages() const;
-    [[nodiscard]] std::u32string getParsedPage(const unsigned int page) const;
-    void cache(const std::u32string &cacheDir, const bool overwrite);
-
+    [[nodiscard]] std::vector<std::string> getParsedPages() const;
+    [[nodiscard]] std::string getParsedPage(const unsigned int page) const;
+    void cache(const std::wstring &cacheDir, const bool overwrite);
 private:
     // Class Members
-    std::u32string file_name_; // file name and extension, not a full path
-    std::u32string path_; // absolute path of the file, including file name and extension
+    std::wstring file_name_; // file name and extension, not a full path
+    std::wstring path_; // absolute path of the file, including file name and extension
     std::string md5_hash_; // the md5 hash of the file. empty if it cannot be calculated
-    std::vector<std::u32string> parsed_pages_; // contains the parsed text of each page of the file
+    std::vector<std::string> parsed_pages_; // contains the parsed text of each page of the file
     // Functions
     void setHash();
     void parsePages();

--- a/SchemaScanLib/SchematicHandler.h
+++ b/SchemaScanLib/SchematicHandler.h
@@ -17,23 +17,24 @@
 
 class SchematicHandler {
 public:
-    SchematicHandler(const std::u32string &path);
+    SchematicHandler(const std::wstring &path);
     ~SchematicHandler();
     [[nodiscard]] int getSchematicCount() const;
     [[nodiscard]] int getFoundFilesCount() const;
     [[nodiscard]] int getSkippedSchematicCount() const;
-    [[nodiscard]] std::vector<std::u32string> getSkippedSchematics() const;
+    [[nodiscard]] std::vector<std::wstring> getSkippedSchematics() const;
     [[nodiscard]] std::vector<Schematic*> getSchematics() const;
-    void cacheAll(const std::u32string &cacheDir, const bool overwrite) const;
+    void cacheAll(const bool overwrite) const;
 private:
     void Scan();
     void Search();
-    std::set<std::u32string> fpaths_; // contains absolute paths of all files found, valid or invalid
+    std::set<std::wstring> fpaths_; // contains absolute paths of all files found, valid or invalid
     std::vector<Schematic*> schematics_; // contains valid parsed Schematic objects
-    std::vector<std::u32string> skipped_schematic_paths_; // contains file paths of skipped schematics (failed to calculate hash which means it would likely fail to scan)
-    std::u32string base_directory_; // initial directory used to search for files
-    std::set<std::string> hash_set_; // contains hashes of the valid parsed Schematic objects in schematics_.
-                                     // used to weed out duplicates
+    std::vector<std::wstring> skipped_schematic_paths_; // contains file paths of skipped schematics
+    std::wstring base_directory_; // initial directory used to search for files
+    std::set<std::string> hash_set_; // contains hashes of the valid parsed Schematic objects in schematics_
+    std::wstring localAppDataPath; // Holds the path to the current user's %LOCALAPPDATA% path (user/AppData/local)
+    std::wstring winCachePath; // Holds the Windows cache path for the user (currently user/AppData/local/SchemaScan/cache)
 };
 
 

--- a/SchemaScanLib/utils/SchemaUtils.cpp
+++ b/SchemaScanLib/utils/SchemaUtils.cpp
@@ -14,7 +14,7 @@
  * @param fpath The (absolute) file path that you wish to check
  * @return A boolean, whether the path points directly to a .pdf file
  */
-bool SchemaUtils::isPdfFile(const std::u32string &fpath) {
+bool SchemaUtils::isPdfFile(const std::wstring &fpath) {
     return hasFileExt(fpath, ".pdf");
 }
 
@@ -23,7 +23,7 @@ bool SchemaUtils::isPdfFile(const std::u32string &fpath) {
  * @param fpath The (absolute) file path that you wish to check
  * @return A boolean, whether the path points directly to a .json file
  */
-bool SchemaUtils::isJsonFile(const std::u32string &fpath) {
+bool SchemaUtils::isJsonFile(const std::wstring &fpath) {
     return hasFileExt(fpath, ".json");
 }
 
@@ -33,12 +33,12 @@ bool SchemaUtils::isJsonFile(const std::u32string &fpath) {
  * @param extension The extension that you wish to check for (e.g. ".pdf")
  * @return A boolean, whether the path points at a file with said extension
  */
-bool SchemaUtils::hasFileExt(const std::u32string &fpath, const std::string &extension) {
+bool SchemaUtils::hasFileExt(const std::wstring &fpath, const std::string &extension) {
     return std::filesystem::path(fpath).extension() == extension;
 }
 
 /**
- * Converts std::u32string to a std::string
+ * Converts std::wstring to a std::string
  * @param u32_string The u32string to be converted
  * @return A converted std::string
  */
@@ -48,13 +48,29 @@ std::string SchemaUtils::u32StringToStdString(const std::u32string &u32_string) 
 }
 
 /**
- * Converts std::string to std::u32string
+ * Converts std::string to std::wstring
  * @param string The std::string to be converted
- * @return A converted std::u32string
+ * @return A converted std::wstring
  */
-std::u32string SchemaUtils::stdStringToU32String(const std::string &string) {
+std::u32string SchemaUtils::stdStringToU32String(const std::string &str) {
     static std::wstring_convert<std::codecvt_utf8<char32_t >, char32_t > converter;
-    return converter.from_bytes(string);
+    return converter.from_bytes(str);
+}
+
+/**
+ * Converts a std::wstring to std::string
+ * @param w_string
+ * @return
+ */
+std::string SchemaUtils::wstringToStdString(const std::wstring &w_string) {
+    static std::wstring_convert<std::codecvt_utf8<wchar_t >, wchar_t > converter;
+    return converter.to_bytes(w_string);
+}
+
+// Converts a std::string to std::wstring
+std::wstring SchemaUtils::stdStringToWString(const std::string &str) {
+    static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
+    return converter.from_bytes(str);
 }
 
 /**
@@ -63,8 +79,8 @@ std::u32string SchemaUtils::stdStringToU32String(const std::string &string) {
  * @param fpath The (absolute) file path that you wish to get information from
  * @return
  */
-std::u32string SchemaUtils::getNameFromPath(const std::u32string &fpath) {
-    std::u32string fileName = getNameAndExtFromPath(fpath);
+std::wstring SchemaUtils::getNameFromPath(const std::wstring &fpath) {
+    std::wstring fileName = getNameAndExtFromPath(fpath);
     if (fileName.find('.') != std::string::npos) {
         std::size_t foundAt = fileName.find_last_of('.');
         return fileName.substr(0, foundAt);
@@ -78,7 +94,7 @@ std::u32string SchemaUtils::getNameFromPath(const std::u32string &fpath) {
  * @param fpath The (absolute) file path that you wish to get information from
  * @return
  */
-std::u32string SchemaUtils::getNameAndExtFromPath(const std::u32string &fpath) {
+std::wstring SchemaUtils::getNameAndExtFromPath(const std::wstring &fpath) {
     std::size_t foundAt;
     if (fpath.find('/') != std::string::npos) {
         foundAt = fpath.find_last_of('/');
@@ -94,7 +110,7 @@ std::u32string SchemaUtils::getNameAndExtFromPath(const std::u32string &fpath) {
  * @param fpath The (absolute) file path that you wish to get information from
  * @return
  */
-std::u32string SchemaUtils::getDirectoryFromPath(const std::u32string &fpath) {
+std::wstring SchemaUtils::getDirectoryFromPath(const std::wstring &fpath) {
     std::size_t foundAt;
     if (fpath.find('/') != std::string::npos) {
         foundAt = fpath.find_last_of('/');
@@ -114,17 +130,17 @@ std::u32string SchemaUtils::getDirectoryFromPath(const std::u32string &fpath) {
  * @param type Default Absolute. A fileNameType enum that determines the type of string(s) that you will get back
  * @return A set of
  */
-std::set<std::u32string> SchemaUtils::searchDirectoryFor(const std::u32string &directory, const std::string &extension,
+std::set<std::wstring> SchemaUtils::searchDirectoryFor(const std::wstring &directory, const std::string &extension,
                                                          const fileNameType &type) {
-    std::u32string prefix = U"\\\\?\\";
-    std::set<std::u32string> found;
+    std::wstring prefix = L"\\\\?\\";
+    std::set<std::wstring> found;
     // Prefix and directory option necessary for long file paths on Windows. Without these the iteration stops
     // and throws an error when it encounters a directory that's too long. The directory option also keeps the iterator
     // from throwing an error if it hits a directory or file that it doesn't have permission to access
     for (const auto &pathIt: std::filesystem::recursive_directory_iterator(
             prefix + directory, std::filesystem::directory_options::skip_permission_denied)) {
-        if (hasFileExt(pathIt.path().u32string(), extension)) {
-            std::u32string absPath = pathIt.path().u32string();
+        if (hasFileExt(pathIt.path().wstring(), extension)) {
+            std::wstring absPath = pathIt.path().wstring();
             if (type == fileNameType::Extension) {
                 found.insert(getNameAndExtFromPath(absPath));
             }

--- a/SchemaScanLib/utils/SchemaUtils.h
+++ b/SchemaScanLib/utils/SchemaUtils.h
@@ -16,15 +16,17 @@ public:
         Extension,
         NoExtension
     };
-    static bool isPdfFile(const std::u32string &fpath);
-    static bool isJsonFile(const std::u32string &fpath);
-    static bool hasFileExt(const std::u32string &fpath, const std::string &extension);
+    static bool isPdfFile(const std::wstring &fpath);
+    static bool isJsonFile(const std::wstring &fpath);
+    static bool hasFileExt(const std::wstring &fpath, const std::string &extension);
     static std::string u32StringToStdString(const std::u32string &u32_string);
-    static std::u32string stdStringToU32String(const std::string &string);
-    static std::u32string getNameFromPath(const std::u32string &fpath);
-    static std::u32string getNameAndExtFromPath(const std::u32string &fpath);
-    static std::u32string getDirectoryFromPath(const std::u32string &fpath);
-    static std::set<std::u32string> searchDirectoryFor(const std::u32string &directory, const std::string &extension,
+    static std::u32string stdStringToU32String(const std::string &str);
+    static std::string wstringToStdString(const std::wstring &w_string);
+    static std::wstring stdStringToWString(const std::string &str);
+    static std::wstring getNameFromPath(const std::wstring &fpath);
+    static std::wstring getNameAndExtFromPath(const std::wstring &fpath);
+    static std::wstring getDirectoryFromPath(const std::wstring &fpath);
+    static std::set<std::wstring> searchDirectoryFor(const std::wstring &directory, const std::string &extension,
                                                        const fileNameType &type = fileNameType::Absolute);
 };
 


### PR DESCRIPTION
Converted all u32string to wstring, and added windows cache path instead of asking user to provide (currently %PROGRAMFILES%/SchemaScan/cache